### PR TITLE
Sample app should show the FHIR resource types in the menu by default.

### DIFF
--- a/src/app/components/resources/resources-table-container/resources-table-container.component.ts
+++ b/src/app/components/resources/resources-table-container/resources-table-container.component.ts
@@ -88,8 +88,10 @@ export class ResourcesTableContainerComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this._route.params.subscribe(val => {
       this.resourceType = this._route.snapshot.paramMap.get('resourceType');
-      this.ccdsResourceType = this._CCDSResourceHelperService.getCCDSResourceFromName(this._route.snapshot.fragment);
-      console.log(this.ccdsResourceType);
+      if(!!environment.showCCDSResourceMenuInstead){
+        this.ccdsResourceType = this._CCDSResourceHelperService.getCCDSResourceFromName(this._route.snapshot.fragment);
+        console.log(this.ccdsResourceType);
+      }   
       this._smartService.getClient()
         .takeUntil(this._unsubscribe)
         .subscribe(smartClient => {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  showCCDSResourceMenuInstead: true
+  showCCDSResourceMenuInstead: false
 };


### PR DESCRIPTION
Sample app should show the FHIR resource types in the menu by default.

Fixed the console error thrown when the app is not in CCDS menu mode.